### PR TITLE
Added diagonal Q method to FishLeg linear layer.

### DIFF
--- a/src/optim/FishLeg/fishleg.py
+++ b/src/optim/FishLeg/fishleg.py
@@ -3,7 +3,12 @@ import torch
 import torch.nn as nn
 import copy
 from torch.optim import Optimizer, Adam
-from torch.optim.optimizer import _use_grad_for_differentiable
+
+try:
+    from torch.optim.optimizer import _use_grad_for_differentiable
+except ImportError:
+    from .utils import _use_grad_for_differentiable
+
 from .utils import recursive_setattr, recursive_getattr, update_dict
 
 from .fishleg_layers import FishLinear

--- a/src/optim/FishLeg/fishleg_layers.py
+++ b/src/optim/FishLeg/fishleg_layers.py
@@ -141,12 +141,12 @@ class FishLinear(nn.Linear, FishModule):
         The diagonal of this matrix is therefore calculated by
 
         .. math::
-                    \text{diag}(Q_l) = (R_l \circ R_l \otimes L_l \circ L_l)
+                    \\text{diag}(Q_l) = \\text{diag}(R_l R_l^T) \otimes \\text{diag}(L_l L_l^T)
 
-        where :math:`\circ` is the Hadamard operation and :math:`\otimes` remains as
+        where :math:`\\text{diag}` involves summing over the columns of the and :math:`\otimes` remains as
         the Kronecker product.
 
         """
         L = torch.sqrt(self.fishleg_aux["scale"]) * self.fishleg_aux["L"]
         R = torch.sqrt(self.fishleg_aux["scale"]) * self.fishleg_aux["R"]
-        return torch.kron((L * L), (R * R))
+        return torch.kron(torch.sum(L * L, axis=1), torch.sum(R * R, axis=1))

--- a/src/optim/FishLeg/fishleg_layers.py
+++ b/src/optim/FishLeg/fishleg_layers.py
@@ -138,7 +138,7 @@ class FishLinear(nn.Linear, FishModule):
         size :math:`N_l \\times N_l`. The auxiliarary parameters :math:`\lambda`
         are represented by the matrices :math:`L_l, R_l`.
 
-        The diagonal of this matrix is therefore calculated by relacing the
+        The diagonal of this matrix is therefore calculated by
 
         .. math::
                     Q_l = (R_l \circ R_l \otimes L_l \circ L_l)

--- a/src/optim/FishLeg/fishleg_layers.py
+++ b/src/optim/FishLeg/fishleg_layers.py
@@ -149,4 +149,4 @@ class FishLinear(nn.Linear, FishModule):
         """
         L = torch.sqrt(self.fishleg_aux["scale"]) * self.fishleg_aux["L"]
         R = torch.sqrt(self.fishleg_aux["scale"]) * self.fishleg_aux["R"]
-        return torch.kron(torch.sum(L * L, axis=1), torch.sum(R * R, axis=1))
+        return torch.kron(torch.sum(R * R, axis=1), torch.sum(L * L, axis=1))

--- a/src/optim/FishLeg/fishleg_layers.py
+++ b/src/optim/FishLeg/fishleg_layers.py
@@ -141,7 +141,7 @@ class FishLinear(nn.Linear, FishModule):
         The diagonal of this matrix is therefore calculated by
 
         .. math::
-                    Q_l = (R_l \circ R_l \otimes L_l \circ L_l)
+                    \text{diag}(Q_l) = (R_l \circ R_l \otimes L_l \circ L_l)
 
         where :math:`\circ` is the Hadamard operation and :math:`\otimes` remains as
         the Kronecker product.

--- a/src/optim/FishLeg/utils.py
+++ b/src/optim/FishLeg/utils.py
@@ -1,9 +1,11 @@
 import torch.nn as nn
+import torch
 
 __all__ = [
     "recursive_setattr",
     "recursive_getattr",
     "update_dict",
+    "_use_grad_for_differentiable",
 ]
 
 
@@ -33,3 +35,16 @@ def update_dict(replace: nn.Module, module: nn.Module) -> nn.Module:
     replace_dict.update(pretrained_dict)
     replace.load_state_dict(replace_dict)
     return replace
+
+
+def _use_grad_for_differentiable(func):
+    def _use_grad(self, *args, **kwargs):
+        prev_grad = torch.is_grad_enabled()
+        try:
+            torch.set_grad_enabled(self.defaults["differentiable"])
+            ret = func(self, *args, **kwargs)
+        finally:
+            torch.set_grad_enabled(prev_grad)
+        return ret
+
+    return _use_grad


### PR DESCRIPTION
I think this is correct? Please check and let me know.

$\text{diag}(Q_l) = \text{diag}(R_l R_l^T) \otimes \text{diag}(L_l L_l^T)$

where $\text{diag}$ denotes the diagonal elements of the argument and $\otimes$ remains as the Kronecker product.

This can then be further decomposed into an elementwise multiplication $\circ$ and a sum as:

$\text{diag}(Q_l) = \sum_{i}(R_l \circ R_l) \otimes \sum_{i}(L_l \circ L_l)$

Also check the implementation - there may be a better way to do this?